### PR TITLE
Enhance API with activity signup, unregistration, and validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,20 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is currently signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team-based soccer training and inter-school matches",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly games",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore drawing, painting, and creative visual arts",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Society": {
+        "description": "Acting, stage performance, and school theater productions",
+        "schedule": "Wednesdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Debate Club": {
+        "description": "Develop public speaking and critical argumentation skills",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 16,
+        "participants": ["elijah@mergington.edu", "james@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Hands-on experiments and preparation for science competitions",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 14,
+        "participants": ["evelyn@mergington.edu", "abigail@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,21 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function escapeHtml(text) {
+    const escaped = document.createElement("div");
+    escaped.textContent = text;
+    return escaped.innerHTML;
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch(`/activities?ts=${Date.now()}`, { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +26,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${escapeHtml(participant)}</span>
+                    <button
+                      type="button"
+                      class="participant-remove"
+                      data-activity="${encodeURIComponent(name)}"
+                      data-email="${encodeURIComponent(participant)}"
+                      aria-label="Remove ${escapeHtml(participant)} from ${escapeHtml(name)}"
+                      title="Unregister participant"
+                    >
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : '<li class="participant-item-empty">No participants yet</li>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants</strong></p>
+            <ul class="participants-list">
+              ${participantsList}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +113,51 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".participant-remove");
+    if (!removeButton) {
+      return;
+    }
+
+    const encodedActivity = removeButton.dataset.activity;
+    const encodedEmail = removeButton.dataset.email;
+
+    if (!encodedActivity || !encodedEmail) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodedActivity}/signup?email=${encodedEmail}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to unregister participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -60,9 +60,10 @@ section h3 {
 .activity-card {
   margin-bottom: 15px;
   padding: 15px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+  border: 1px solid #d6defa;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #f9fbff 0%, #f4f7ff 100%);
+  box-shadow: 0 4px 12px rgba(30, 60, 150, 0.08);
 }
 
 .activity-card h4 {
@@ -72,6 +73,80 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.participants-section {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid #d9e1ff;
+  border-radius: 8px;
+  background-color: #ffffff;
+}
+
+.participants-title {
+  margin-bottom: 6px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #24325c;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border: 1px solid #e4e9ff;
+  border-radius: 6px;
+  background-color: #f9fbff;
+}
+
+.participant-item-empty {
+  padding: 6px 2px;
+  color: #5f6e9b;
+  font-style: italic;
+}
+
+.participant-email {
+  font-size: 0.95rem;
+  color: #24325c;
+  word-break: break-word;
+}
+
+.participant-remove {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #f1c1c1;
+  border-radius: 999px;
+  background-color: #fff3f3;
+  color: #c62828;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.12s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.participant-remove:hover {
+  background-color: #ffe1e1;
+  border-color: #e5a1a1;
+  transform: scale(1.06);
+}
+
+.participant-remove:focus-visible {
+  outline: 2px solid #3949ab;
+  outline-offset: 2px;
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(original_activities))
+
+
+@pytest.fixture
+def client():
+    with TestClient(app_module.app) as test_client:
+        yield test_client

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,17 @@
+def test_get_activities_returns_expected_structure(client):
+    # Arrange
+    required_keys = {"description", "schedule", "max_participants", "participants"}
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    activities = response.json()
+    assert "Chess Club" in activities
+    assert "Programming Class" in activities
+    assert "Gym Class" in activities
+
+    for details in activities.values():
+        assert required_keys.issubset(details.keys())
+        assert isinstance(details["participants"], list)

--- a/tests/test_root_redirect.py
+++ b/tests/test_root_redirect.py
@@ -1,0 +1,10 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    root_path = "/"
+
+    # Act
+    response = client.get(root_path, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,41 @@
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    participant_email = "new-student@mergington.edu"
+    before_count = len(client.get("/activities").json()[activity_name]["participants"])
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {participant_email} for {activity_name}"
+    participants = client.get("/activities").json()[activity_name]["participants"]
+    assert participant_email in participants
+    assert len(participants) == before_count + 1
+
+
+def test_signup_duplicate_participant_returns_400(client):
+    # Arrange
+    activity_name = "Chess Club"
+    participant_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    participant_email = "someone@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,42 @@
+def test_unregister_removes_existing_participant(client):
+    # Arrange
+    activity_name = "Gym Class"
+    participant_email = "john@mergington.edu"
+    before_participants = client.get("/activities").json()[activity_name]["participants"]
+    before_count = len(before_participants)
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {participant_email} from {activity_name}"
+    participants = client.get("/activities").json()[activity_name]["participants"]
+    assert participant_email not in participants
+    assert len(participants) == before_count - 1
+
+
+def test_unregister_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    participant_email = "someone@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_non_registered_participant_returns_404(client):
+    # Arrange
+    activity_name = "Debate Club"
+    participant_email = "not-registered@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": participant_email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"


### PR DESCRIPTION
This pull request adds new extracurricular activities to the system, introduces participant management features (including unregistering students from activities), and improves the frontend to display and manage participants interactively. It also adds comprehensive tests for API endpoints and ensures test isolation. The most important changes are grouped below by theme.

### Backend: Activity and Participant Management

* Added several new activities to the `activities` dictionary in `src/app.py`, expanding the available extracurricular options.
* Introduced the `unregister_from_activity` endpoint to allow students to be removed from activity participant lists, with validation for activity existence and participant status.

### Frontend: Participant Display and Removal

* Enhanced the frontend (`src/static/app.js`) to show participants for each activity, including a remove button for each participant, and implemented logic to unregister participants via the new API endpoint. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R61) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R119-R163)
* Improved activity card styling and added styles for participant lists and remove buttons in `src/static/styles.css`. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2L63-R66) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R78-R151)

### Testing: API and State Management

* Added fixtures to reset activity state between tests for isolation, and introduced tests for listing activities, signing up, unregistering, and root redirect behavior. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R20) [[2]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R17) [[3]](diffhunk://#diff-221e9bb48798738439a2b32ae0ac86f31b097ee6febc01f406901e485855475cR1-R10) [[4]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R41) [[5]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R42)